### PR TITLE
template.yaml: Update DeploymentTargets description

### DIFF
--- a/CloudFormation/template.yaml
+++ b/CloudFormation/template.yaml
@@ -41,7 +41,7 @@ Parameters:
     - 'false'
     Description: Specify if this solution is being deployed in a delegated adminstrator account. With this option you no longer need to be logged into the AWS Organizations management account to administer software package distribution.
   DeploymentTargets:
-    Description: Specify AWS account IDs and/or the organizational unit IDs within AWS Organization whose accounts have the target instances (e.g., ou-abcd-1qwert43, 123456789123) for distribution
+    Description: Specify AWS account IDs and/or the organizational unit IDs within AWS Organization whose accounts have the target instances (e.g., ou-abcd-1qwert43, 123456789123) for distribution. (Account IDs are only allowed when updating, when first running this stack use OU IDs)
     Type: CommaDelimitedList
   TargetKey:
     Type: String


### PR DESCRIPTION
*Issue:*

According to the doc https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DeploymentTargets.html the DeploymentTargets can only be OrganizationalUnitIds for create operations. Indeed, using Account IDs causes the stack to fail with "failed validation constraint for keyword [pattern]"

![Captura de tela de 2022-08-17 06-03-08](https://user-images.githubusercontent.com/84111478/185150908-e994e871-2ae4-4d37-922c-2034a0899148.png)

*Description of changes:*

Update the description of DeploymentTargets to make it clear that when running this terraform for the first time Account IDs are actually not allowed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
